### PR TITLE
Fix shiny color palette update issue

### DIFF
--- a/app/gene-plot-Pi-4sps-optim-PCATEST.Rmd
+++ b/app/gene-plot-Pi-4sps-optim-PCATEST.Rmd
@@ -7743,10 +7743,10 @@ server <- function(input, output, session) {
         colourpicker::updateColourInput(session, input_id, value = new_colors[[sp]])
       }
     }
-    #reset flag after flush to allow individual picker changes
-    shiny::onFlushed(function() {
+    #reset flag after client round-trip completes
+    later::later(function() {
       plot_settings$updating_colors_from_palette <- FALSE
-    }, once = TRUE)
+    }, delay = 0.3)
   })
   
   observeEvent(input$settings_multigene_color, {
@@ -7825,15 +7825,18 @@ server <- function(input, output, session) {
   observe({
     req(plot_settings$initialized)
     #skip if palette update is in progress to avoid reactive loop
-    if (isTRUE(plot_settings$updating_colors_from_palette)) return()
-    config <- current_species_config()
+    #use isolate to prevent flag changes from re-triggering this observer
+    if (isTRUE(isolate(plot_settings$updating_colors_from_palette))) return()
+    config <- isolate(current_species_config())
     species_list <- sapply(config, function(x) x$short)
     
     for (sp in species_list) {
       input_id <- paste0("species_color_", gsub("[^a-zA-Z0-9]", "_", sp))
       val <- input[[input_id]]
-      if (!is.null(val) && !is.null(plot_settings$species_colors[[sp]])) {
-        if (val != plot_settings$species_colors[[sp]]) {
+      #isolate stored color read so this observer only triggers on input changes
+      stored_color <- isolate(plot_settings$species_colors[[sp]])
+      if (!is.null(val) && !is.null(stored_color)) {
+        if (val != stored_color) {
           plot_settings$species_colors[[sp]] <- val
           #also update full name key
           sp_full <- config[[names(config)[sapply(config, function(x) x$short == sp)]]]$name

--- a/app/gene-plot-Pi-4sps-optim-PCATEST.Rmd
+++ b/app/gene-plot-Pi-4sps-optim-PCATEST.Rmd
@@ -7731,7 +7731,15 @@ server <- function(input, output, session) {
     config <- current_species_config()
     species_list <- sapply(config, function(x) x$short)
     plot_settings$species_palette <- input$settings_species_palette
-    plot_settings$species_colors <- derive_species_colors(species_list, input$settings_species_palette, NULL, config)
+    new_colors <- derive_species_colors(species_list, input$settings_species_palette, NULL, config)
+    plot_settings$species_colors <- new_colors
+    #update colourInput UI elements to reflect new palette
+    for (sp in species_list) {
+      input_id <- paste0("species_color_", gsub("[^a-zA-Z0-9]", "_", sp))
+      if (sp %in% names(new_colors)) {
+        colourpicker::updateColourInput(session, input_id, value = new_colors[[sp]])
+      }
+    }
   })
   
   observeEvent(input$settings_multigene_color, {

--- a/app/gene-plot-Pi-4sps-optim-PCATEST.Rmd
+++ b/app/gene-plot-Pi-4sps-optim-PCATEST.Rmd
@@ -6801,6 +6801,7 @@ server <- function(input, output, session) {
     species_palette = "Dark2",
     species_colors = list(),
     species_shapes = list(),
+    updating_colors_from_palette = FALSE,
     
     #multi-gene line/point encoding
     encoding_multigene_color = "species",
@@ -7733,6 +7734,8 @@ server <- function(input, output, session) {
     plot_settings$species_palette <- input$settings_species_palette
     new_colors <- derive_species_colors(species_list, input$settings_species_palette, NULL, config)
     plot_settings$species_colors <- new_colors
+    #flag to prevent individual picker observer from triggering during palette update
+    plot_settings$updating_colors_from_palette <- TRUE
     #update colourInput UI elements to reflect new palette
     for (sp in species_list) {
       input_id <- paste0("species_color_", gsub("[^a-zA-Z0-9]", "_", sp))
@@ -7740,6 +7743,10 @@ server <- function(input, output, session) {
         colourpicker::updateColourInput(session, input_id, value = new_colors[[sp]])
       }
     }
+    #reset flag after flush to allow individual picker changes
+    shiny::onFlushed(function() {
+      plot_settings$updating_colors_from_palette <- FALSE
+    }, once = TRUE)
   })
   
   observeEvent(input$settings_multigene_color, {
@@ -7817,6 +7824,8 @@ server <- function(input, output, session) {
   #update species_colors directly when individual color pickers change
   observe({
     req(plot_settings$initialized)
+    #skip if palette update is in progress to avoid reactive loop
+    if (isTRUE(plot_settings$updating_colors_from_palette)) return()
     config <- current_species_config()
     species_list <- sapply(config, function(x) x$short)
     


### PR DESCRIPTION
Update color picker UI and plotly output when a new species color palette is selected.

The `colourInput` elements generated by `renderUI` do not automatically re-render when their underlying reactive values change. Explicit `colourpicker::updateColourInput()` calls are now used to reflect the new palette colors in the UI, and the plotly output correctly reflects the updated reactive `plot_settings$species_colors`.

---
<a href="https://cursor.com/background-agent?bcId=bc-06caea92-36eb-4f63-b57c-edaa7b86e15b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-06caea92-36eb-4f63-b57c-edaa7b86e15b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

